### PR TITLE
Fix error formatting "count" results

### DIFF
--- a/dql/engine.py
+++ b/dql/engine.py
@@ -312,7 +312,7 @@ class Engine(object):
         if tree.consistent:
             kwargs['consistent'] = True
 
-        return self.connection.query(tablename, count=True, **kwargs)
+        return [{'count': self.connection.query(tablename, count=True, **kwargs)}]
 
     def _delete(self, tree):
         """ Run a DELETE statement """


### PR DESCRIPTION
Hi math campers (btw what does that mean?), thanks for dql, it is really cool and useful!  While trying it out I was getting this error when running the `count` command, which is fixed in this PR.

```
us-east-1> count test_Rollups WHERE key = 'XXXX';
Traceback (most recent call last):
  File "/home/cce/dql.env/lib/python2.7/site-packages/dql/cli.py", line 120, in start
    self.cmdloop()
  File "/usr/lib/python2.7/cmd.py", line 142, in cmdloop
    stop = self.onecmd(line)
  File "/usr/lib/python2.7/cmd.py", line 220, in onecmd
    return self.default(line)
  File "/home/cce/dql.env/lib/python2.7/site-packages/dql/cli.py", line 313, in default
    self._run_cmd(command)
  File "/home/cce/dql.env/lib/python2.7/site-packages/dql/cli.py", line 324, in _run_cmd
    has_more = self.formatter.write(results, ostream)
  File "/home/cce/dql.env/lib/python2.7/site-packages/dql/output.py", line 91, in write
    for result in results:
TypeError: 'int' object is not iterable
```
