### PR TITLE
Fix default encoding bug on mac

### DIFF
--- a/dql/output.py
+++ b/dql/output.py
@@ -286,7 +286,11 @@ class SmartBuffer(object):
 
     def __init__(self, buf):
         self._buffer = buf
-        self.encoding = locale.getdefaultlocale()[1] or 'utf-8'
+        try:
+            self.encoding = locale.getdefaultlocale()[1] or 'utf-8'
+        except ValueError:
+            self.encoding = 'utf-8'
+            
 
     def write(self, arg):
         """ Write a string or bytes object to the buffer """


### PR DESCRIPTION
In this PR I have tried to fix ValueError which happens during initialization of SmartBuffer on mac OS:
```
(127.0.0.1:6432) ap-southeast-1> scan * from mytable;
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/dql/cli.py", line 195, in start
    self.cmdloop()
  File "/usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/lib/python2.7/cmd.py", line 142, in cmdloop
    stop = self.onecmd(line)
  File "/usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/lib/python2.7/cmd.py", line 220, in onecmd
    return self.default(line)
  File "/usr/local/lib/python2.7/site-packages/dql/cli.py", line 578, in default
    self._run_cmd(command)
  File "/usr/local/lib/python2.7/site-packages/dql/cli.py", line 608, in _run_cmd
    with self.display() as ostream:
  File "/usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/lib/python2.7/contextlib.py", line 17, in __enter__
    return self.gen.next()
  File "/usr/local/lib/python2.7/site-packages/dql/output.py", line 327, in stdout_display
    yield SmartBuffer(sys.stdout)
  File "/usr/local/lib/python2.7/site-packages/dql/output.py", line 289, in __init__
    self.encoding = locale.getdefaultlocale()[1] or 'utf-8'
  File "/usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/lib/python2.7/locale.py", line 545, in getdefaultlocale
    return _parse_localename(localename)
  File "/usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/lib/python2.7/locale.py", line 477, in _parse_localename
    raise ValueError, 'unknown locale: %s' % localename
ValueError: unknown locale: UTF-8
```

There is a [quick fix](https://coderwall.com/p/-k_93g/mac-os-x-valueerror-unknown-locale-utf-8-in-python) for this problem but I believe there should be a default encoding; not an error. 


Additional information:

```
➜  ~ python   
[GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import locale
>>> locale.getdefaultlocale()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/lib/python2.7/locale.py", line 545, in getdefaultlocale
    return _parse_localename(localename)
  File "/usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/lib/python2.7/locale.py", line 477, in _parse_localename
    raise ValueError, 'unknown locale: %s' % localename
ValueError: unknown locale: UTF-8
```