### PR TITLE
Fix DQL to work with Python 3

### DIFF
--- a/dql/output.py
+++ b/dql/output.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """ Formatting and displaying output """
 from __future__ import unicode_literals
+from builtins import input
+from builtins import range
 
 import locale
 import os
@@ -40,7 +42,7 @@ def wrap(string, length, indent):
     """ Wrap a string at a line length """
     newline = '\n' + ' ' * indent
     return newline.join((string[i:i + length]
-                         for i in xrange(0, len(string), length)))
+                         for i in range(0, len(string), length)))
 
 
 def serialize_json_var(obj):
@@ -128,7 +130,7 @@ class BaseFormat(object):
 
     def wait(self):
         """ Block for user input """
-        text = raw_input(
+        text = input(
             "Press return for next %d result%s (or type 'all'):"
             % (self.pagesize, plural(self.pagesize)))
         if text:
@@ -322,4 +324,7 @@ def less_display():
 @contextlib.contextmanager
 def stdout_display():
     """ Print results straight to stdout """
-    yield SmartBuffer(sys.stdout)
+    if six.PY2:
+        yield SmartBuffer(sys.stdout)
+    else:
+        yield SmartBuffer(sys.stdout.buffer)

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ CHANGES = open(os.path.join(HERE, 'CHANGES.rst')).read()
 REQUIREMENTS = [
     'dynamo3>=0.4.7',
     'six>=1.10.0',
+    'future>=0.15.0',
     'pyparsing==2.1.4',
     'python-dateutil',
 ]


### PR DESCRIPTION
I was getting some exceptions when running DQL over Python 3, so I took the liberty to fix them. As you can see in the single commit, the `xrange` and `raw_input` are Python 2 specific. Also, the `sys.stdout` buffer cannot write bytes data, only string. By replacing `sys.stdout` with `sys.stdout.buffer` in Python 3, the problem is fixed.