### PR TITLE
Add 'output_json_as_list' option to CLI (WIP)

### DIFF
--- a/dql/cli.py
+++ b/dql/cli.py
@@ -66,6 +66,7 @@ DEFAULT_CONFIG = {
     "display": "stdout",
     "format": "smart",
     "allow_select_scan": False,
+    "output_json_as_list": False,
     "_throttle": {},
 }
 
@@ -394,6 +395,16 @@ class DQLClient(cmd.Cmd):
 
     def complete_opt_allow_select_scan(self, text, *_):
         """ Autocomplete for allow_select_scan option """
+        return [t for t in ("true", "false", "yes", "no") if t.startswith(text.lower())]
+
+    def opt_output_json_as_list(self, output):
+        """ Set option output_json_as_list """
+        output = output.lower() in ("true", "t", "yes", "y")
+        self.conf["output_json_as_list"] = output
+        self.engine.output_json_as_list = output
+
+    def complete_opt_output_json_as_list(self, text, *_):
+        """ Autocomplete for output_json_as_list option """
         return [t for t in ("true", "false", "yes", "no") if t.startswith(text.lower())]
 
     @repl_command

--- a/dql/engine.py
+++ b/dql/engine.py
@@ -128,6 +128,7 @@ class Engine(object):
         self.rate_limit = None
         self._encoder = json.JSONEncoder(separators=(",", ":"), default=default)
         self.caution_callback = None
+        self.output_json_as_list = False
 
     def connect(self, *args, **kwargs):
         """ Proxy to DynamoDBConnection.connect. """
@@ -598,10 +599,17 @@ class Engine(object):
                         writer.writerow(item)
             elif ext.lower() == ".json":
                 with opened as ofile:
-                    for item in result:
+                    (start, delim, end) = ("[", ",\n", "]\n")\
+                      if self.output_json_as_list else ("", "\n", "\n")
+                    ofile.write(start)
+                    for item in result[:-1]:
                         count += 1
                         ofile.write(self._encoder.encode(item))
-                        ofile.write("\n")
+                        ofile.write(delim)
+                    if len(result) > 0:
+                        count += 1
+                        ofile.write(self._encoder.encode(result[-1]))
+                    ofile.write(end)
             else:
                 with opened as ofile:
                     for item in result:

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -495,6 +495,59 @@ class TestSelect(BaseSystemTest):
         self.assertEqual(list(ret), [{"bar": 2}])
 
 
+class TestSaveJson(BaseSystemTest):
+
+    """ Tests that involve saving the results into a JSON file """
+
+    def setUp(self):
+        super(TestSaveJson, self).setUp()
+        self.test_file_name = 'out.json'
+        self.engine.output_json_as_list = True
+
+    def test_no_results(self):
+        """ JSON output with no results """
+        self.make_table()
+        self.query("SCAN * FROM foobar SAVE " + self.test_file_name)
+        contents = self._get_file_contents()
+        self.assertEqual(contents, "[]\n")
+
+    def test_one_result(self):
+        """ JSON output with one result """
+        self.make_table()
+        self.query("INSERT INTO foobar (id, bar) VALUES ('a', 1)")
+        self.query("SCAN * FROM foobar SAVE " + self.test_file_name)
+        contents = self._get_file_contents()
+        self.assertEqual(contents, '[{"bar":1,"id":"a"}]\n')
+
+    def test_two_results(self):
+        """ JSON output with two results """
+        self.make_table()
+        self.query("INSERT INTO foobar (id, bar) VALUES ('a', 1), ('b', 2)")
+        self.query("SCAN * FROM foobar SAVE " + self.test_file_name)
+        contents = self._get_file_contents()
+        self.assertEqual(
+            contents,
+            '[{"bar":2,"id":"b"},\n{"bar":1,"id":"a"}]\n'
+        )
+
+    def test_three_results(self):
+        """ JSON output with three results """
+        self.make_table()
+        self.query(
+            "INSERT INTO foobar (id, bar) VALUES ('a', 1), ('b', 2), ('c', 3)"
+        )
+        self.query("SCAN * FROM foobar SAVE " + self.test_file_name)
+        contents = self._get_file_contents()
+        self.assertEqual(
+            contents,
+            '[{"bar":2,"id":"b"},\n{"bar":3,"id":"c"},\n{"bar":1,"id":"a"}]\n'
+        )
+
+    def _get_file_contents(self):
+        with open(self.test_file_name, 'r') as f:
+            return f.read()
+
+
 class TestSelectScan(BaseSystemTest):
 
     """ Tests for SELECT that involve doing a table scan """


### PR DESCRIPTION
Everything about this is still WIP, opening it up early in case I'm misunderstanding something.

By the way I needed to change this line on Windows to

```python
opened = open(filename, "w")
```

to get the tests to pass:

https://github.com/stevearc/dql/blob/6b0ab8df07afd226816937ee98b4ef73187206fc/dql/engine.py#L581

Fixes https://github.com/stevearc/dql/issues/21.