### PR TITLE
throttle: fix Python 3 compatibility

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.26
+current_version = 0.5.27
 tag_name = {new_version}
 files = setup.py doc/conf.py dql/__init__.py
 commit = True

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 python: "3.6"
 env:
   - TOXENV=py27
-  - TOXENV=py34
   - TOXENV=py36
   - TOXENV=lint
 matrix:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -23,7 +23,7 @@ project = u'dql'
 copyright = u'2013, Steven Arcangeli'
 github_user = u'stevearc'
 
-release = '0.5.26'
+release = '0.5.27'
 version = '.'.join(release.split('.')[:2])
 
 exclude_patterns = ['_build']

--- a/dql/__init__.py
+++ b/dql/__init__.py
@@ -8,7 +8,7 @@ import logging.config
 from .cli import DQLClient
 from .engine import Engine, FragmentEngine
 
-__version__ = "0.5.26"
+__version__ = "0.5.27"
 
 
 LOG_CONFIG = {

--- a/dql/throttle.py
+++ b/dql/throttle.py
@@ -55,7 +55,7 @@ class TableLimits(object):
             kwargs["total_write"] = float(self.total["write"])
         return RateLimit(**kwargs)
 
-    def __nonzero__(self):
+    def __bool__(self):
         return (
             bool(self.tables)
             or bool(self.indexes)
@@ -63,6 +63,8 @@ class TableLimits(object):
             or bool(self.total)
         )
 
+    __nonzero__ = __bool__
+    
     def _set_limit(self, data, key, read, write):
         """ Set a limit or delete if non provided """
         if read != "0" or write != "0":

--- a/dql/throttle.py
+++ b/dql/throttle.py
@@ -64,7 +64,7 @@ class TableLimits(object):
         )
 
     __nonzero__ = __bool__
-    
+
     def _set_limit(self, data, key, read, write):
         """ Set a limit or delete if non provided """
         if read != "0" or write != "0":

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ EXTRAS = {
 if __name__ == "__main__":
     setup(
         name="dql",
-        version="0.5.26",
+        version="0.5.27",
         description="DynamoDB Query Language",
         long_description=README + "\n\n" + CHANGES,
         classifiers=[


### PR DESCRIPTION
On Python 3, dql is always performing a "describe all" due to throttle not being falsy.