### PR TITLE
Better errors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+# Matches multiple files with brace expansion notation
+# Set default charset
+[*.{js,py}]
+charset = utf-8
+
+# 4 space indentation
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.{js,json,yml}]
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ pip-log.txt
 .coverage
 .tox
 nosetests.xml
+coverage_html/
 
 # Translations
 *.mo

--- a/dql/cli.py
+++ b/dql/cli.py
@@ -5,7 +5,6 @@ import json
 import os
 import shlex
 import subprocess
-import traceback
 from builtins import input
 from collections import OrderedDict
 from fnmatch import fnmatch

--- a/dql/cli.py
+++ b/dql/cli.py
@@ -3,6 +3,7 @@ import cmd
 import functools
 import json
 import os
+import random
 import shlex
 import subprocess
 from builtins import input
@@ -147,7 +148,8 @@ def exception_handler(engine):
     try:
         yield
     except KeyboardInterrupt:
-        console.print("KeyboardInterrupt by user")
+        spooky_season = [":skull:", ":vampire:", ":zombie:", ":jack-o-lantern:"]
+        console.print(random.choice(spooky_season))
     except botocore.exceptions.BotoCoreError as e:
         console.log("BotoCoreError: ", e)
     except ParseException as e:

--- a/dql/cli.py
+++ b/dql/cli.py
@@ -7,6 +7,7 @@ import shlex
 import subprocess
 from builtins import input
 from collections import OrderedDict
+from contextlib import contextmanager
 from fnmatch import fnmatch
 
 import botocore
@@ -140,6 +141,31 @@ def get_enum_key(key, choices):
         return keys[0]
 
 
+@contextmanager
+def exception_handler(engine):
+    """ It is a context manager which can handle exceptions and deal with them. """
+    try:
+        yield
+    except KeyboardInterrupt:
+        console.print("KeyboardInterrupt by user")
+    except botocore.exceptions.BotoCoreError as e:
+        console.log("BotoCoreError: ", e)
+    except ParseException as e:
+        console.log("Engine: ParseException")
+        syntax = Syntax(
+            engine.pformat_exc(e),
+            "sql",
+            theme="monokai",
+            line_numbers=True,
+            word_wrap=True,
+        )
+        console.print(Panel(syntax, title="Engine Details", expand=False))
+    except SyntaxError as e:
+        console.log(e)
+    except Exception:
+        console.print_exception()
+
+
 class DQLClient(cmd.Cmd):
 
     """
@@ -204,37 +230,13 @@ class DQLClient(cmd.Cmd):
         self.throttle = TableLimits()
         self.throttle.load(self.conf["_throttle"])
 
-    def with_exception_handling(self, func_name, *args, **kwargs):
-        """ Will run the given function with the supplied args and kwargs and handle any exceptions. """
-        try:
-            func = getattr(self, func_name)
-            # console.log("Running a function: " + func_name + "() with *args, **kwargs", log_locals=True)
-            func(*args, **kwargs)
-        except KeyboardInterrupt:
-            console.print("KeyboardInterrupt by user")
-        except botocore.exceptions.BotoCoreError as e:
-            console.log("BotoCoreError: ", e)
-        except ParseException as e:
-            console.log("Engine: ParseException")
-            syntax = Syntax(
-                self.engine.pformat_exc(e),
-                "sql",
-                theme="monokai",
-                line_numbers=True,
-                word_wrap=True,
-            )
-            console.print(Panel(syntax, title="Engine Details", expand=False))
-        except SyntaxError as e:
-            console.log(e)
-        except Exception:
-            console.print_exception()
-
     def start(self):
         """ Start running the interactive session (blocking) """
         self.running = True
         while self.running:
             self.update_prompt()
-            self.with_exception_handling("cmdloop")
+            with exception_handler(self.engine):
+                self.cmdloop()
             self.engine.reset()
 
     def postcmd(self, stop, line):
@@ -686,7 +688,8 @@ class DQLClient(cmd.Cmd):
         """ Run a command passed in from the command line with -c """
         self.display = DISPLAYS["stdout"]
         self.conf["pagesize"] = 0
-        self.with_exception_handling("onecmd", command)
+        with exception_handler(self.engine):
+            self.onecmd(command)
 
     def emptyline(self):
         self.default("")

--- a/dql/engine.py
+++ b/dql/engine.py
@@ -497,8 +497,8 @@ class Engine(object):
         (action, query_kwargs, index) = self._build_query(desc, tree, visitor)
         if action == "scan" and not allow_select_scan:
             raise SyntaxError(
-                "No index found for query. Please use a SCAN query, or "
-                "set allow_select_scan=True\nopt allow_select_scan true"
+                "No index found for query. Please use a 'SCAN' query, or "
+                "set the option allow_select_scan=True.\nRun command 'help opt' for info on options."
             )
         order_by = None
         if tree.order_by:

--- a/dql/output.py
+++ b/dql/output.py
@@ -15,8 +15,11 @@ from decimal import Decimal
 
 from dateutil.relativedelta import relativedelta
 from dynamo3 import Binary
+from rich.console import Console
 
 from .util import getmaxyx, plural
+
+console = Console()
 
 
 def truncate(string, length, ellipsis="…"):

--- a/dql/util.py
+++ b/dql/util.py
@@ -20,9 +20,9 @@ try:
 except ImportError:
     try:
         import os
+        import struct
         from fcntl import ioctl
         from termios import TIOCGWINSZ
-        import struct
 
         def getmaxyx():
             """ Get the terminal height and width """

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,8 @@ REQUIREMENTS = [
     "dynamo3>=0.4.7",
     "pyparsing==2.1.4",
     "python-dateutil",
+    "botocore>=1.17.55",
+    "rich>=6.1.1",
 ]
 
 EXTRAS = {

--- a/tox.ini
+++ b/tox.ini
@@ -37,3 +37,14 @@ extras =
 commands =
     isort -y -ac -rc dql tests setup.py bin/install.py
     black dql tests setup.py bin/install.py
+
+[testenv:coverage]
+deps =
+    coverage
+commands =
+    coverage run --source=dql --branch setup.py nosetests --verbosity=2
+    coverage report
+    coverage html
+
+[coverage:html]
+directory = coverage_html


### PR DESCRIPTION
- Added Requirements
    - `botocore`
    - `rich`
- Handling errors for queries ran via `-c` option.
- Implemented rich traceback handler.
- Adding `.editorconfig`

## KeyboardInterrupt
#### old
<img width="379" alt="old_keyboard_interrupt" src="https://user-images.githubusercontent.com/2302194/92669239-f7117780-f2de-11ea-95ca-3dc039d52292.png">

#### new
<img width="402" alt="new_keyboard_interrupt" src="https://user-images.githubusercontent.com/2302194/92669216-e9f48880-f2de-11ea-8a75-192bb880d3d4.png">

Useful to see the interrupt when dealing with long running queries or when interrupting multi page results. I am not too firm on this, I can remove this or change it to a different output. Maybe an emoji? 🧛 

## BotoCoreError
#### old
<img width="373" alt="old_botocore_error" src="https://user-images.githubusercontent.com/2302194/92669470-a8181200-f2df-11ea-8111-1df23e4e49d8.png">

#### new
<img width="484" alt="new_botocore_error" src="https://user-images.githubusercontent.com/2302194/92669452-9b93b980-f2df-11ea-8666-f19664d9b95c.png">

Little bit more context on where the error comes from. Time of the log. 


## SyntaxError
#### old
<img width="880" alt="old_SyntaxError" src="https://user-images.githubusercontent.com/2302194/92669043-6f2b6d80-f2de-11ea-811e-7210d7097969.png">

#### new
<img width="872" alt="new_SyntaxError" src="https://user-images.githubusercontent.com/2302194/92669085-8cf8d280-f2de-11ea-99b9-5b1af465fc9f.png">

Don't really need the whole stack trace as a user. It would be better to implement a `--debug` option at some point instead.


## ParseException 
#### old
<img width="528" alt="old_parse_error" src="https://user-images.githubusercontent.com/2302194/92669757-76ec1180-f2e0-11ea-821c-68bc678a6526.png">

#### new
<img width="814" alt="new_parse_exceptions" src="https://user-images.githubusercontent.com/2302194/92669961-f2e65980-f2e0-11ea-93f9-8b311544ad43.png">

Context around the error. Syntax highlighted panel with the details.

## Exception
![unhandled_exceptions](https://user-images.githubusercontent.com/2302194/92670656-7d7b8880-f2e2-11ea-888d-771f1c9187f2.png)

better stack trace around the unhandled Exceptions.


# Running with `-c` 
Running with `dql -c "query"` will use the same exception handler as running in interactive mode. So all the above handling screenshots will apply to the -c mode as well.

## BotoCoreError
<img width="1025" alt="old_-c_botocore" src="https://user-images.githubusercontent.com/2302194/92669607-1066f380-f2e0-11ea-8d6a-ebb2917a6314.png">
<img width="587" alt="new_-c_botocore" src="https://user-images.githubusercontent.com/2302194/92669677-3a201a80-f2e0-11ea-8670-324f5eba5f94.png">

Here we see that before this change the `-c` mode would not handle exceptions and cause a full stack trace and was inconsistent with the error handling on the interactive mode.

# Spooky Season Updates
![keyboard_interrupt_emojis](https://user-images.githubusercontent.com/2302194/92672431-a9990880-f2e6-11ea-9b25-246a22167fc4.png)

Keyboard interrupts will print emojis to the screen for the spooky season. 🧛  🎃  🧟  💀 
