### PR TITLE
Fixed #31: On-Demand tables cause ZeroDivisionError with ls

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+0.5.29-dev0
+-----------
+WIP: Tracking all changes for the next version. Actual version number will be decided later.
+* Bug fix: Fixed ZeroDivisionError with ls on On-Demand tables (#32)
+* Added: Better error handling and display. (#28)
+* Added: Standard error handling for execution with ``-c`` option. (#28)
+* Added: Keyboard interrupts will print spooky emojis. (#28)
+* Chore: General Dev Env & CI updates for easier development. (#27)
+
 0.5.28
 ------
 * Bug fix: Encoding errors for some SAVE file formats

--- a/dql/models.py
+++ b/dql/models.py
@@ -7,6 +7,8 @@ from dynamo3.fields import snake_to_camel
 
 def format_throughput(available, used=None):
     """ Format the read/write throughput for display """
+    if available == 0 or not isinstance(available, (int, float)):
+        return "N/A"
     if used is None:
         return str(available)
     percent = float(used) / available

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,6 @@
 """ Tests for model classes """
+from dql.models import format_throughput
+
 from . import BaseSystemTest
 
 
@@ -15,3 +17,28 @@ class TestModels(BaseSystemTest):
         desc = self.engine.describe("foobar", refresh=True)
         self.assertEqual(desc.total_read_throughput, 2)
         self.assertEqual(desc.total_write_throughput, 2)
+
+    def test_format_throughput_for_available_throughput(self):
+        """ Returns the properly formatted string for the throughput. """
+        actual = format_throughput(20)
+        self.assertEqual(actual, "20")
+
+    def test_format_throughput_for_two_inputs(self):
+        """ Returns the properly formatted string based on the inputs. """
+        actual = format_throughput(20, 10)
+        self.assertEqual(actual, "10/20 (50%)")
+
+    def test_format_throughput_for_two_inputs_which_will_result_in_a_fraction(self):
+        """ Returns the properly formatted string based on the inputs. """
+        actual = format_throughput(20, 7)
+        self.assertEqual(actual, "7/20 (35%)")
+
+    def test_format_throughput_for_when_available_is_zero(self):
+        """ Returns N/A as the available throughput is 0 """
+        self.assertEqual(format_throughput(0, 7), "N/A")
+        self.assertEqual(format_throughput(0), "N/A")
+
+    def test_format_throughput_for_when_available_is_NaN(self):
+        """ Returns N/A as the available throughput is NaN """
+        self.assertEqual(format_throughput("asd", 7), "N/A")
+        self.assertEqual(format_throughput("asd"), "N/A")


### PR DESCRIPTION
- Fixed #31 
- Added unit tests for the same.