### PR TITLE
Dynamo local path to be within project root + gitignore

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.6.0
+current_version = 0.6.1-dev0
 tag_name = {new_version}
 files = setup.py doc/conf.py dql/__init__.py
 commit = True
@@ -17,4 +17,3 @@ values =
 	prod
 
 [bumpversion:part:build]
-

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ _build
 
 # vim
 *.swp
+
+# dynamo local service
+.dynamo-local

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+0.6.1-dev0
+----------
+* Chore: Updated config for Dynamo Local to install dependency within project root.
+
 0.6.0
 -----
 * Bug fix: Fixed ZeroDivisionError with ls on On-Demand tables (#32)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -23,7 +23,7 @@ project = u'dql'
 copyright = u'2013, Steven Arcangeli'
 github_user = u'stevearc'
 
-release = '0.6.0'
+release = '0.6.1-dev0'
 version = '.'.join(release.split('.')[:2])
 
 exclude_patterns = ['_build']

--- a/dql/__init__.py
+++ b/dql/__init__.py
@@ -6,7 +6,7 @@ import os
 from .cli import DQLClient
 from .engine import Engine, FragmentEngine
 
-__version__ = "0.6.0"
+__version__ = "0.6.1-dev0"
 __all__ = ["Engine", "FragmentEngine", "DQLClient"]
 
 LOG_CONFIG = {

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,7 @@
 match = ^test
 with-dynamo=true
 dynamo-port=8002
+dynamo-path=.dynamo-local
 
 [wheel]
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ REQUIREMENTS_TEST = open(os.path.join(HERE, "requirements_test.txt")).readlines(
 if __name__ == "__main__":
     setup(
         name="dql",
-        version="0.6.0",
+        version="0.6.1-dev0",
         description="DynamoDB Query Language",
         long_description=README + "\n\n" + CHANGES,
         classifiers=[


### PR DESCRIPTION
## Fixing Dynamo local issues
- Fixing intermittent issues with dynamo local when using with default path.
    - When the dynamo local is using default path, for some reason that I can not figure out, the dynamo local stops working after a while and the tests fail. 
- This change removes the magic of hidden dynamo local and places it with in the project root dir. So that the existence of dynamo local is readily apparent.

## Tracking towards next release.
- Updated the patch version to a dev build. The release version can be decided later.
- Updated changelog.
